### PR TITLE
Port AS530 changes from 1.8.3 and fix DME decimals

### DIFF
--- a/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.css
+++ b/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.css
@@ -99,12 +99,19 @@ as530-element {
             as530-element #Electricity #TopDisplay #RadioPart #VorRad #VOR div, as530-element #Electricity #TopDisplay #RadioPart #VorRad #RAD div {
               width: 49%; }
         as530-element #Electricity #TopDisplay #RadioPart #VOR, as530-element #Electricity #TopDisplay #RadioPart #RAD, as530-element #Electricity #TopDisplay #RadioPart #DIS {
-          color: white; }
+          color: white;
+          font-size: 5vh;
+          height: 7.7vh; }
         as530-element #Electricity #TopDisplay #RadioPart #vorTitle, as530-element #Electricity #TopDisplay #RadioPart #radTitle, as530-element #Electricity #TopDisplay #RadioPart #disTitle {
           color: #6ecdee; }
         as530-element #Electricity #TopDisplay #RadioPart #DIS {
           border: calc(0.4273504274vh) solid #6ecdee;
-          display: flex; }
+          display: flex;
+          width: 100%; }
+          as530-element #Electricity #TopDisplay #RadioPart #DIS div {
+            width: 45%; }
+          as530-element #Electricity #TopDisplay #RadioPart #DIS .unit {
+            width: 9%; }
         as530-element #Electricity #TopDisplay #RadioPart #BotRadioPartTop, as530-element #Electricity #TopDisplay #RadioPart #BotRadioPartMid, as530-element #Electricity #TopDisplay #RadioPart #BotRadioPartBot {
           background-color: black;
           border: calc(0.4273504274vh) solid #6ecdee;
@@ -551,6 +558,8 @@ as530-element {
           as530-element #Electricity #TopDisplay #GpsPart #WaypointSelection .Value {
             font-size: calc(7.264957265vh);
             margin: calc(0.8547008547vh); }
+          as530-element #Electricity #TopDisplay #GpsPart #WaypointSelection #WPSPosNS, as530-element #Electricity #TopDisplay #GpsPart #WaypointSelection #WPSPosEW {
+            height: calc(7.264957265vh); }
           as530-element #Electricity #TopDisplay #GpsPart #WaypointSelection .Half {
             width: 48%; }
           as530-element #Electricity #TopDisplay #GpsPart #WaypointSelection #WPSInfos {

--- a/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.js
+++ b/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.js
@@ -35,6 +35,26 @@ class AS530 extends BaseGPS {
         this.addEventLinkedPageGroup("FPL_Push", new NavSystemPageGroup("FPL", this, [new NavSystemPage("ActiveFPL", "FlightPlanEdit", new GPS_ActiveFPL())]));
         this.addEventLinkedPageGroup("PROC_Push", new NavSystemPageGroup("PROC", this, [new NavSystemPage("Procedures", "Procedures", new GPS_Procedures())]));
         this.addEventLinkedPageGroup("MSG_Push", new NavSystemPageGroup("MSG", this, [new NavSystemPage("MSG", "MSG", new GPS_Messages())]));
+        this.addIndependentElementContainer(new NavSystemElementContainer("VorInfos", "RadioPart", new AS530_VorInfos()));
+    }
+}
+class AS530_VorInfos extends NavSystemElement {
+    init(root) {
+        this.vor = this.gps.getChildById("vorValue");
+        this.rad = this.gps.getChildById("radValue");
+        this.dis = this.gps.getChildById("disValue");
+    }
+    onEnter() {
+    }
+    onExit() {
+    }
+    onEvent(_event) {
+    }
+    onUpdate(_deltaTime) {
+        let ident = SimVar.GetSimVarValue("NAV IDENT:1", "string");
+        Avionics.Utils.diffAndSet(this.vor, ident != "" ? ident : "___");
+        Avionics.Utils.diffAndSet(this.rad, (SimVar.GetSimVarValue("NAV HAS NAV:1", "bool") ? Math.round(SimVar.GetSimVarValue("NAV RELATIVE BEARING TO STATION:1", "degrees")).toFixed(0) : "___") + "°");
+        Avionics.Utils.diffAndSet(this.dis, (SimVar.GetSimVarValue("NAV HAS DME:1", "bool") ? Math.round(SimVar.GetSimVarValue("NAV DME:1", "Nautical Miles")).toFixed(1) : "__._"));
     }
 }
 registerInstrument("as530-element", AS530);

--- a/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.js
+++ b/html_ui/Pages/VCockpit/Instruments/NavSystems/GPS/AS530/AS530.js
@@ -54,7 +54,13 @@ class AS530_VorInfos extends NavSystemElement {
         let ident = SimVar.GetSimVarValue("NAV IDENT:1", "string");
         Avionics.Utils.diffAndSet(this.vor, ident != "" ? ident : "___");
         Avionics.Utils.diffAndSet(this.rad, (SimVar.GetSimVarValue("NAV HAS NAV:1", "bool") ? Math.round(SimVar.GetSimVarValue("NAV RELATIVE BEARING TO STATION:1", "degrees")).toFixed(0) : "___") + "°");
-        Avionics.Utils.diffAndSet(this.dis, (SimVar.GetSimVarValue("NAV HAS DME:1", "bool") ? Math.round(SimVar.GetSimVarValue("NAV DME:1", "Nautical Miles")).toFixed(1) : "__._"));
+        if (SimVar.GetSimVarValue("NAV HAS DME:1", "bool")) {
+            const distance = SimVar.GetSimVarValue("NAV DME:1", "Nautical Miles");
+            const distanceFixed = distance.toFixed(1);
+            Avionics.Utils.diffAndSet(this.dis, distanceFixed < 100.0 ? distanceFixed : Math.round(distance));
+        } else {
+            Avionics.Utils.diffAndSet(this.dis, "__._");
+        }
     }
 }
 registerInstrument("as530-element", AS530);


### PR DESCRIPTION
- Port patch 1.8.3 changes (a7b0174)
    - Adds missing VOR/RAD and DME distance to AS530
- Fix incorrect decimals with DME distance (e6382e6)
   - Original code has always zero decimal, e.g. 4.0...3.0...2.0 nm which is incorrect
   - After fix there are no decimals if farther than 100nm and is single decimal if closer e.g. 101...100...99.9...99.8... nm

**DME DIS**
![kuva](https://user-images.githubusercontent.com/24453333/94349149-a6be4780-004a-11eb-89e1-7624a13a4108.png)

**Note**: There can be other porting needed in other parts of the mod so it would be good to do a diff to latest official files.